### PR TITLE
Make Odoo validation gates explicit

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -21,10 +21,12 @@
       "default": "uv run mcp-test",
       "unit": "uv run mcp-test-unit",
       "integration": "uv run mcp-test-integration",
-      "ci": "uv run pytest tests/unit -m \"not integration\" --no-cov -q -k \"not test_get_container_with_auto_start and not test_restart_container_autostart_success\""
+      "ci": "uv run mcp-test-ci",
+      "liveStack": "uv run mcp-test-live"
     },
     "coverage": {
       "default": "uv run mcp-test-cov",
+      "liveStack": "uv run mcp-test-live-cov",
       "minimumPercent": 75
     },
     "inspection": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,4 @@ jobs:
         run: uv sync --locked --group dev
 
       - name: Run unit tests
-        env:
-          SKIPPED_DOCKER_TESTS: >-
-            not test_get_container_with_auto_start and
-            not test_restart_container_autostart_success
-        run: |
-          uv run pytest tests/unit -m "not integration" --no-cov -q \
-            -k "$SKIPPED_DOCKER_TESTS"
+        run: uv run mcp-test-ci

--- a/README.md
+++ b/README.md
@@ -155,16 +155,24 @@ Large responses are validated and may include warnings or truncation to respect 
 ### Testing Requirements
 
 ```bash
-# Run the full suite (must pass)
+# Default no-live-stack gate for local/PR validation.
+# Excludes tests that require a live Docker daemon or Odoo container.
 uv run mcp-test
 
 # Alternatives
-uv run mcp-test-unit        # Unit tests
-uv run mcp-test-integration # Integration tests
-uv run mcp-test-cov         # With coverage report
+uv run mcp-test-ci          # CI unit gate
+uv run mcp-test-unit        # Unit tests only
+uv run mcp-test-integration # Mocked/non-live integration tests
+uv run mcp-test-live        # Live Docker/Odoo integration tests
+uv run mcp-test-cov         # No-live-stack coverage report
+uv run mcp-test-live-cov    # Live Docker/Odoo coverage report
 
-# Threshold: 75% minimum coverage (current fail-under 74.5 in pyproject)
+# Threshold: 75% minimum coverage for the documented coverage gate.
 ```
+
+`mcp-test-live` and `mcp-test-live-cov` require the target Docker/Odoo workspace to be available. During the broader Odoo refactor,
+use the no-live-stack gate for ordinary MCP changes and run the live-stack gate when validating runtime behavior against the current
+Odoo workspace.
 
 ### Code Quality
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,10 @@ odoo-intelligence-mcp = "odoo_intelligence_mcp.server:main"
 mcp-test = "odoo_intelligence_mcp.cli:test"
 mcp-test-unit = "odoo_intelligence_mcp.cli:test_unit"
 mcp-test-integration = "odoo_intelligence_mcp.cli:test_integration"
+mcp-test-ci = "odoo_intelligence_mcp.cli:test_ci"
+mcp-test-live = "odoo_intelligence_mcp.cli:test_live"
 mcp-test-cov = "odoo_intelligence_mcp.cli:test_cov"
+mcp-test-live-cov = "odoo_intelligence_mcp.cli:test_live_cov"
 mcp-format = "odoo_intelligence_mcp.cli:format_code"
 mcp-check = "odoo_intelligence_mcp.cli:check"
 mcp-clean = "odoo_intelligence_mcp.cli:clean"
@@ -132,6 +135,8 @@ markers = [
     "asyncio: Asynchronous tests",
     "mock: Tests that use mocking",
     "docker: Tests that require Docker containers",
+    "requires_docker: Tests that require a live Docker daemon",
+    "requires_odoo: Tests that require a live Odoo container/workspace",
 ]
 asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
@@ -181,7 +186,7 @@ exclude_lines = [
     "^\\s*pass\\s*$",
     "^\\s*\\.\\.\\.\\s*$",
 ]
-fail_under = 70
+fail_under = 75
 
 [tool.coverage.html]
 directory = "htmlcov"

--- a/src/odoo_intelligence_mcp/cli.py
+++ b/src/odoo_intelligence_mcp/cli.py
@@ -3,25 +3,42 @@ import subprocess
 import sys
 from pathlib import Path
 
+NO_LIVE_STACK_MARKERS = "not requires_docker and not requires_odoo"
+LIVE_STACK_MARKERS = "requires_docker or requires_odoo"
+CI_TEST_EXPRESSION = "not test_get_container_with_auto_start and not test_restart_container_autostart_success"
+
+
+def _run_pytest(*arguments: str) -> None:
+    result = subprocess.run([sys.executable, "-m", "pytest", *arguments])
+    sys.exit(result.returncode)
+
 
 def test() -> None:
-    result = subprocess.run([sys.executable, "-m", "pytest"])
-    sys.exit(result.returncode)
+    _run_pytest("-m", NO_LIVE_STACK_MARKERS)
 
 
 def test_unit() -> None:
-    result = subprocess.run([sys.executable, "-m", "pytest", "tests/unit", "-m", "not integration"])
-    sys.exit(result.returncode)
+    _run_pytest("tests/unit", "-m", "not integration", "--no-cov")
 
 
 def test_integration() -> None:
-    result = subprocess.run([sys.executable, "-m", "pytest", "tests/integration", "-m", "integration"])
-    sys.exit(result.returncode)
+    _run_pytest("tests/integration", "-m", f"integration and {NO_LIVE_STACK_MARKERS}", "--no-cov")
+
+
+def test_ci() -> None:
+    _run_pytest("tests/unit", "-m", "not integration", "--no-cov", "-q", "-k", CI_TEST_EXPRESSION)
+
+
+def test_live() -> None:
+    _run_pytest("tests/integration", "-m", LIVE_STACK_MARKERS, "--no-cov")
 
 
 def test_cov() -> None:
-    result = subprocess.run([sys.executable, "-m", "pytest", "--cov", "--cov-report=term-missing", "--cov-report=html"])
-    sys.exit(result.returncode)
+    _run_pytest("-m", NO_LIVE_STACK_MARKERS, "--cov", "--cov-report=term-missing", "--cov-report=html")
+
+
+def test_live_cov() -> None:
+    _run_pytest("tests/integration", "-m", LIVE_STACK_MARKERS, "--cov", "--cov-report=term-missing", "--cov-report=html")
 
 
 def format_code() -> None:

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,24 +27,54 @@ tests/
 
 ## Running Tests
 
-### All Tests
+### Default No-Live-Stack Gate
+
+Use this for normal local and PR validation. It excludes tests that require a live Docker daemon or Odoo container.
+
 ```bash
 uv run mcp-test
 ```
 
-### Unit Tests Only
+### CI Unit Gate
+
+This mirrors the GitHub Actions test command.
+
 ```bash
-uv run pytest tests/unit/ -v
+uv run mcp-test-ci
 ```
 
-### Integration Tests Only
+### Unit Tests Only
+
 ```bash
-uv run pytest tests/integration/ -v
+uv run mcp-test-unit
+```
+
+### Mocked/No-Live Integration Tests
+
+These run integration tests that do not require a live Docker/Odoo stack.
+
+```bash
+uv run mcp-test-integration
+```
+
+### Live Docker/Odoo Integration Tests
+
+These require the target Docker/Odoo workspace to be available.
+
+```bash
+uv run mcp-test-live
 ```
 
 ### With Coverage
+
 ```bash
 uv run mcp-test-cov
+```
+
+### Live Docker/Odoo Coverage
+
+```bash
+uv run mcp-test-live-cov
 ```
 
 ### Specific Test File
@@ -234,11 +264,16 @@ When adding new features:
 
 ## Common Issues
 
-### Docker Not Available
-Some integration tests require Docker. Skip them with:
+### Docker/Odoo Not Available
+
+Some integration tests require the live Docker/Odoo workspace. The default `uv run mcp-test` excludes those tests.
+To select tests manually, use marker expressions:
+
 ```bash
-pytest -m "not docker"
+uv run pytest -m "not requires_docker and not requires_odoo"
 ```
+
+Use `uv run mcp-test-live` only when Docker and the target Odoo workspace are available.
 
 ### Slow Tests
 Run fast unit tests only:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def env_config() -> EnvConfig:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _ensure_container_prefix() -> Generator[None, None, None]:
+def _ensure_container_prefix() -> Generator[None]:
     explicit = any(
         os.getenv(key) for key in ("ODOO_PROJECT_NAME", "ODOO_CONTAINER_NAME", "ODOO_SCRIPT_RUNNER_CONTAINER", "ODOO_WEB_CONTAINER")
     )
@@ -43,7 +43,7 @@ def test_env(env_config: EnvConfig) -> HostOdooEnvironment:
 
 
 @pytest.fixture(scope="session")
-def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+def event_loop() -> Generator[asyncio.AbstractEventLoop]:
     loop = asyncio.new_event_loop()
     yield loop
     loop.close()
@@ -315,7 +315,7 @@ def mock_odoo_env(mock_res_partner_data: dict[str, Any]) -> MagicMock:
                 "name": model_name,
                 "model": model_name,
                 "table": model_name.replace(".", "_"),
-                "description": f"{model_name.split('.')[-1].title().replace('_', ' ')} Model",
+                "description": f"{model_name.rsplit('.', maxsplit=1)[-1].title().replace('_', ' ')} Model",
                 "rec_name": "name",
                 "order": "id",
                 "total_field_count": 3,
@@ -1231,3 +1231,13 @@ def mock_mcp_context() -> dict[str, Any]:
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "requires_docker: mark test as requiring Docker to be running")
     config.addinivalue_line("markers", "requires_odoo: mark test as requiring Odoo instance")
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        fixture_names = getattr(item, "fixturenames", ())
+        if "real_odoo_env_if_available" in fixture_names:
+            item.add_marker(pytest.mark.requires_docker)
+            item.add_marker(pytest.mark.requires_odoo)
+        elif item.get_closest_marker("docker"):
+            item.add_marker(pytest.mark.requires_docker)

--- a/tests/integration/test_field_access_issue.py
+++ b/tests/integration/test_field_access_issue.py
@@ -5,6 +5,8 @@ from odoo_intelligence_mcp.core.env import HostOdooEnvironment, HostOdooEnvironm
 from odoo_intelligence_mcp.tools.field.field_dependencies import get_field_dependencies
 from odoo_intelligence_mcp.tools.field.field_value_analyzer import analyze_field_values
 
+pytestmark = [pytest.mark.requires_docker, pytest.mark.requires_odoo]
+
 
 class TestFieldAccessIntegration:
     @pytest_asyncio.fixture

--- a/tests/unit/services/test_base_service.py
+++ b/tests/unit/services/test_base_service.py
@@ -162,3 +162,71 @@ class TestBaseService:
         mock_env.some_method = Mock(return_value="result")
         # noinspection PyUnresolvedReferences
         assert service.env.some_method() == "result"
+
+    def test_safe_execute_success(self, service: ConcreteService) -> None:
+        def concatenate(first: str, second: str) -> str:
+            return f"{first}-{second}"
+
+        result = service._safe_execute("join values", concatenate, "left", second="right")
+
+        assert result == "left-right"
+
+    def test_safe_execute_preserves_service_errors(self, service: ConcreteService) -> None:
+        service_error = ServiceValidationError("Already service-shaped")
+
+        def raise_service_error() -> None:
+            raise service_error
+
+        with pytest.raises(ServiceValidationError) as exc_info:
+            service._safe_execute("validate", raise_service_error)
+
+        assert exc_info.value is service_error
+
+    def test_safe_execute_wraps_unexpected_errors(self, service: ConcreteService) -> None:
+        def raise_unexpected_error() -> None:
+            raise RuntimeError("boom")
+
+        with pytest.raises(ServiceExecutionError) as exc_info:
+            service._safe_execute("explode", raise_unexpected_error)
+
+        assert str(exc_info.value) == "Failed to execute explode in TestService: boom"
+
+    def test_paginate_results_middle_page(self) -> None:
+        result = ConcreteService._paginate_results(["a", "b", "c", "d", "e"], page=2, page_size=2)
+
+        assert result == {
+            "items": ["c", "d"],
+            "pagination": {
+                "page": 2,
+                "page_size": 2,
+                "total_items": 5,
+                "total_pages": 3,
+                "has_next": True,
+                "has_previous": True,
+            },
+        }
+
+    def test_paginate_results_empty(self) -> None:
+        result = ConcreteService._paginate_results([], page=1, page_size=10)
+
+        assert result == {
+            "items": [],
+            "pagination": {
+                "page": 1,
+                "page_size": 10,
+                "total_items": 0,
+                "total_pages": 0,
+                "has_next": False,
+                "has_previous": False,
+            },
+        }
+
+    def test_format_error_response(self, service: ConcreteService) -> None:
+        response = service._format_error_response(ValueError("bad value"))
+
+        assert response == {
+            "error": True,
+            "error_type": "ValueError",
+            "message": "bad value",
+            "service": "TestService",
+        }

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -13,7 +13,7 @@ class TestCLIFunctions:
         with pytest.raises(SystemExit) as exc_info:
             cli.test()
         assert exc_info.value.code == 0
-        mock_run.assert_called_once_with([sys.executable, "-m", "pytest"])
+        mock_run.assert_called_once_with([sys.executable, "-m", "pytest", "-m", cli.NO_LIVE_STACK_MARKERS])
 
     @patch("odoo_intelligence_mcp.cli.subprocess.run")
     def test_test_unit_function(self, mock_run: MagicMock) -> None:
@@ -21,7 +21,7 @@ class TestCLIFunctions:
         with pytest.raises(SystemExit) as exc_info:
             cli.test_unit()
         assert exc_info.value.code == 0
-        mock_run.assert_called_once_with([sys.executable, "-m", "pytest", "tests/unit", "-m", "not integration"])
+        mock_run.assert_called_once_with([sys.executable, "-m", "pytest", "tests/unit", "-m", "not integration", "--no-cov"])
 
     @patch("odoo_intelligence_mcp.cli.subprocess.run")
     def test_test_integration_function(self, mock_run: MagicMock) -> None:
@@ -29,7 +29,29 @@ class TestCLIFunctions:
         with pytest.raises(SystemExit) as exc_info:
             cli.test_integration()
         assert exc_info.value.code == 0
-        mock_run.assert_called_once_with([sys.executable, "-m", "pytest", "tests/integration", "-m", "integration"])
+        mock_run.assert_called_once_with(
+            [sys.executable, "-m", "pytest", "tests/integration", "-m", f"integration and {cli.NO_LIVE_STACK_MARKERS}", "--no-cov"]
+        )
+
+    @patch("odoo_intelligence_mcp.cli.subprocess.run")
+    def test_test_ci_function(self, mock_run: MagicMock) -> None:
+        mock_run.return_value.returncode = 0
+        with pytest.raises(SystemExit) as exc_info:
+            cli.test_ci()
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once_with(
+            [sys.executable, "-m", "pytest", "tests/unit", "-m", "not integration", "--no-cov", "-q", "-k", cli.CI_TEST_EXPRESSION]
+        )
+
+    @patch("odoo_intelligence_mcp.cli.subprocess.run")
+    def test_test_live_function(self, mock_run: MagicMock) -> None:
+        mock_run.return_value.returncode = 0
+        with pytest.raises(SystemExit) as exc_info:
+            cli.test_live()
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once_with(
+            [sys.executable, "-m", "pytest", "tests/integration", "-m", cli.LIVE_STACK_MARKERS, "--no-cov"]
+        )
 
     @patch("odoo_intelligence_mcp.cli.subprocess.run")
     def test_test_cov_function(self, mock_run: MagicMock) -> None:
@@ -37,7 +59,38 @@ class TestCLIFunctions:
         with pytest.raises(SystemExit) as exc_info:
             cli.test_cov()
         assert exc_info.value.code == 0
-        mock_run.assert_called_once_with([sys.executable, "-m", "pytest", "--cov", "--cov-report=term-missing", "--cov-report=html"])
+        mock_run.assert_called_once_with(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-m",
+                cli.NO_LIVE_STACK_MARKERS,
+                "--cov",
+                "--cov-report=term-missing",
+                "--cov-report=html",
+            ]
+        )
+
+    @patch("odoo_intelligence_mcp.cli.subprocess.run")
+    def test_test_live_cov_function(self, mock_run: MagicMock) -> None:
+        mock_run.return_value.returncode = 0
+        with pytest.raises(SystemExit) as exc_info:
+            cli.test_live_cov()
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once_with(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "tests/integration",
+                "-m",
+                cli.LIVE_STACK_MARKERS,
+                "--cov",
+                "--cov-report=term-missing",
+                "--cov-report=html",
+            ]
+        )
 
     @patch("odoo_intelligence_mcp.cli.subprocess.run")
     def test_format_code_function(self, mock_run: MagicMock) -> None:
@@ -134,6 +187,18 @@ class TestCLIFunctions:
 
         with pytest.raises(SystemExit):
             cli.test_cov()
+        assert mock_run.call_args[0][0][0] == sys.executable
+
+        with pytest.raises(SystemExit):
+            cli.test_ci()
+        assert mock_run.call_args[0][0][0] == sys.executable
+
+        with pytest.raises(SystemExit):
+            cli.test_live()
+        assert mock_run.call_args[0][0][0] == sys.executable
+
+        with pytest.raises(SystemExit):
+            cli.test_live_cov()
         assert mock_run.call_args[0][0][0] == sys.executable
 
         cli.format_code()

--- a/tests/unit/tools/ast/test_ast_index.py
+++ b/tests/unit/tools/ast/test_ast_index.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from odoo_intelligence_mcp.tools.ast.ast_index import build_ast_index
+
+
+@pytest.mark.asyncio
+@patch("odoo_intelligence_mcp.tools.ast.ast_index.DockerClientManager")
+@patch("odoo_intelligence_mcp.tools.ast.ast_index.load_env_config")
+async def test_build_ast_index_uses_configured_addon_roots(mock_load_env_config: MagicMock, mock_docker_class: MagicMock) -> None:
+    config = MagicMock()
+    config.web_container = "odoo-web-1"
+    config.addons_path = "/opt/project/addons, /opt/enterprise,"
+    mock_load_env_config.return_value = config
+    docker_manager = mock_docker_class.return_value
+    docker_manager.exec_run.return_value = {"success": True, "stdout": '{"models": {"res.partner": {"class": "Partner"}}}'}
+
+    result = await build_ast_index()
+
+    assert result == {"models": {"res.partner": {"class": "Partner"}}}
+    docker_manager.exec_run.assert_called_once()
+    container_name, command = docker_manager.exec_run.call_args.args
+    assert container_name == "odoo-web-1"
+    assert command[:2] == ["python3", "-c"]
+    assert 'roots = ["/opt/project/addons", "/opt/enterprise"]' in command[2]
+    assert docker_manager.exec_run.call_args.kwargs == {"timeout": 120}
+
+
+@pytest.mark.asyncio
+@patch("odoo_intelligence_mcp.tools.ast.ast_index.DockerClientManager")
+@patch("odoo_intelligence_mcp.tools.ast.ast_index.load_env_config")
+async def test_build_ast_index_uses_explicit_roots(mock_load_env_config: MagicMock, mock_docker_class: MagicMock) -> None:
+    config = MagicMock()
+    config.web_container = "odoo-web-1"
+    config.addons_path = "/unused"
+    mock_load_env_config.return_value = config
+    docker_manager = mock_docker_class.return_value
+    docker_manager.exec_run.return_value = {"success": True, "stdout": '{"models": {}}'}
+
+    await build_ast_index(["/custom/addons"])
+
+    command = docker_manager.exec_run.call_args.args[1]
+    assert 'roots = ["/custom/addons"]' in command[2]
+
+
+@pytest.mark.asyncio
+@patch("odoo_intelligence_mcp.tools.ast.ast_index.DockerClientManager")
+@patch("odoo_intelligence_mcp.tools.ast.ast_index.load_env_config")
+async def test_build_ast_index_returns_exec_failure(mock_load_env_config: MagicMock, mock_docker_class: MagicMock) -> None:
+    config = MagicMock()
+    config.web_container = "odoo-web-1"
+    config.addons_path = "/opt/project/addons"
+    mock_load_env_config.return_value = config
+    docker_manager = mock_docker_class.return_value
+    docker_manager.exec_run.return_value = {"success": False, "stderr": "no container", "error": "DockerError"}
+
+    result = await build_ast_index()
+
+    assert result == {"success": False, "error": "no container", "error_type": "DockerError", "container": "odoo-web-1"}
+
+
+@pytest.mark.asyncio
+@patch("odoo_intelligence_mcp.tools.ast.ast_index.DockerClientManager")
+@patch("odoo_intelligence_mcp.tools.ast.ast_index.load_env_config")
+async def test_build_ast_index_returns_parse_failure(mock_load_env_config: MagicMock, mock_docker_class: MagicMock) -> None:
+    config = MagicMock()
+    config.web_container = "odoo-web-1"
+    config.addons_path = "/opt/project/addons"
+    mock_load_env_config.return_value = config
+    docker_manager = mock_docker_class.return_value
+    docker_manager.exec_run.return_value = {"success": True, "stdout": "not json"}
+
+    result = await build_ast_index()
+
+    assert result["success"] is False
+    assert result["error"].startswith("Failed to parse AST index:")
+    assert result["error_type"] == "JSONDecodeError"


### PR DESCRIPTION
## Summary
- split validation into explicit no-live, CI, integration, live-stack, and live-stack coverage commands
- mark Docker/Odoo-dependent tests with `requires_docker` / `requires_odoo`, including automatic compatibility mapping from existing fixtures and `docker` markers
- point GitHub Actions and repo workflow metadata at the new CI command
- document when to use no-live gates during the Odoo refactor and when to run live-stack gates afterward
- align the coverage fail-under with the documented 75% gate and add focused tests to keep that gate passing

Closes #12
Refs #13
Refs #8

## Validation
- `uv lock --locked`
- `uv run mcp-format`
- `uv run mcp-test-ci` -> 607 passed, 2 deselected
- `uv run mcp-test` -> 719 passed, 1 skipped, 79 deselected, coverage 75.12% with fail-under 75.0
- `uv run mcp-test-integration` -> 33 passed, 1 skipped, 156 deselected
- `uv run mcp-test-live` -> expected current-refactor failure: selected live Docker/Odoo tests but the local stack cannot start because the Odoo image/volume context is not stable yet (`odoo-opw-local:latest` missing and volume project mismatch)
- `git diff --check`
- `actionlint .github/workflows/ci.yml`

## Notes
This PR intentionally makes the live-stack gate explicit without making it a required CI blocker yet. The post-refactor live validation expansion is tracked in #13 and linked to the active Odoo-system refactor issues there.
