### PR TITLE
Use github.json for workflow metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -32,7 +32,11 @@
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",
-      "scopePreference": ["changed_files", "directory", "whole_project"]
+      "scopePreference": [
+        "changed_files",
+        "directory",
+        "whole_project"
+      ]
     },
     "docsRequiredWhen": [
       "behavior changes",
@@ -46,7 +50,9 @@
       "test or coverage command changes"
     ]
   },
-  "importantWorkflows": ["CI"],
+  "importantWorkflows": [
+    "CI"
+  ],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],
@@ -58,7 +64,6 @@
     "odoo-tenant-cm",
     "odoo-tenant-opw"
   ],
-  "validatedThrough": ["odoo-tenant-cm", "odoo-tenant-opw"],
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,
@@ -88,7 +93,6 @@
       "primary commands change",
       "important workflows change",
       "repo relationship changes",
-      "validated-through repos change",
       "cleanup policy changes",
       "ownership boundaries change",
       "MCP tool contract changes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ for archival investigation.
 
 ## Workflow Metadata
 
-- Use [`.github/github-repo-workflow.json`](.github/github-repo-workflow.json)
+- Use [`.github/github.json`](.github/github.json)
   for setup, run, format, test, coverage, inspection, and cleanup routing.
 
 ## Code Standards


### PR DESCRIPTION
## Summary
- rename repo workflow metadata from `.github/github-repo-workflow.json` to `.github/github.json`
- update local guidance/docs to point at the canonical metadata path
- drop retired `validatedThrough` metadata while preserving the rest of the workflow facts

## Validation
- `jq empty .github/github.json`
- confirmed `.github/github-repo-workflow.json` is removed
- confirmed repo docs no longer reference `.github/github-repo-workflow.json`
- confirmed `.github/github.json` has no `validatedThrough` / `validated-through` entries
- compared old and new JSON content, allowing only the retired `validatedThrough` field/trigger removal
- `git diff --check`
