### PR TITLE
Classify mcp-clean as routine closeout cleanup

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -84,7 +84,15 @@
   },
   "cleanup": {
     "deleteMergedLocalBranches": true,
-    "removeMergedCleanWorktrees": true
+    "removeMergedCleanWorktrees": true,
+    "commands": [
+      {
+        "name": "mcp-clean",
+        "command": "uv run mcp-clean",
+        "when": "routine",
+        "description": "Remove repo-local Python and test-generated artifacts such as pytest caches, coverage HTML, coverage data, __pycache__ directories, and pyc files."
+      }
+    ]
   },
   "metadataFreshness": {
     "updateWhen": [


### PR DESCRIPTION
## Summary

- Adds `uv run mcp-clean` to `.github/github.json` under `cleanup.commands`.
- Classifies the command as `when: "routine"` because `src/odoo_intelligence_mcp/cli.py::clean` only removes repo-local Python and test-generated artifacts.
- Describes the generated artifacts removed during closeout cleanup.

Closes #23

## Verification

- `jq empty .github/github.json` passed.
- `uv run mcp-format` passed.
- `uv run mcp-clean` passed after test artifact generation.
- `uv run mcp-test` initially failed during collection without Odoo target env because `tests/integration/test_real_docker_integration.py` calls `load_env_config()` in a skip condition.
- `ODOO_PROJECT_NAME=odoo uv run mcp-test` ran tests successfully: 719 passed, 1 skipped, 79 deselected; command exited nonzero because coverage was 74.96% against the 75.00% threshold.
- `ODOO_PROJECT_NAME=odoo uv run mcp-test-cov` ran tests successfully: 719 passed, 1 skipped, 79 deselected; command exited nonzero because coverage was 70.01% against the 75.00% threshold.
- JetBrains closeout for changed files was attempted and timed out waiting for PyCharm to open this exact Launchplane worktree; the helper found the main checkout open instead of the task worktree.
