### PR TITLE
Track pyproject module import

### DIFF
--- a/.idea/odoo-intelligence-mcp.iml
+++ b/.idea/odoo-intelligence-mcp.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
+<module external.system.id="pyproject.toml" type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />


### PR DESCRIPTION
## Summary
- record that the PyCharm module is imported from `pyproject.toml`
- keep `tests` marked as a test source root rather than committing the generated non-test-source flip
- normalize the tracked `.iml` file to end with a newline

## Validation
- `git diff --check`

Refs cbusillo/codex-skills#404
